### PR TITLE
Add a template for running pytest with casatools

### DIFF
--- a/.github/workflows/python-testing-casatools-template.yml
+++ b/.github/workflows/python-testing-casatools-template.yml
@@ -1,0 +1,86 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions.
+
+name: "Python testing with casatools on Linux/macOS (template)"
+
+on:
+  workflow_call:
+    inputs:
+      python-versions:
+        required: false
+        type: string
+        default: '["3.11", "3.12"]'
+      test-path:
+        required: false
+        type: string
+        default: "tests/"
+      cov_project:
+        required: true
+        type: string
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ${{ fromJson(inputs.python-versions) }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-activate-base: false
+          activate-environment: test
+
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          use-only-tar-bz2: true
+          show-channel-urls: true
+          miniforge-version: latest
+
+      - name: Install dependencies with pip
+        run: |
+          python -m pip install --upgrade pip
+          # install the current package
+          pip install .
+          # workaround for the current installation setup.
+          pip uninstall -y python-casacore && pip install casatools 
+          # trigger `casa-data` fetch
+          mkdir -p ~/.casa/data && python -c 'import casatools'          
+          pip install pytest-cov
+
+      - name: Test with pytest
+        run: |
+          pytest -v ${{ inputs.test-path }} \
+          --html=test-results.html --self-contained-html \
+          --cov=${{ inputs.cov_project }} --no-cov-on-fail \
+          --cov-report=html --cov-report=xml --doctest-modules \
+          --junitxml=junit.xml -o junit_family=legacy
+
+      - name: Upload pytest test results and coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}-with-casatools
+          path: |
+            ./test-results.html
+            ./htmlcov
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
+
+      - name: Upload code coverage results to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}
+
+      - name: Upload test stats to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ${{ github.repository }}

--- a/.github/workflows/python-testing-casatools-template.yml
+++ b/.github/workflows/python-testing-casatools-template.yml
@@ -17,6 +17,10 @@ on:
       cov_project:
         required: true
         type: string
+      pytest_ignore:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -57,6 +61,7 @@ jobs:
       - name: Test with pytest
         run: |
           pytest -v ${{ inputs.test-path }} \
+          --ignore=${{ inputs.pytest_ignore }} \
           --html=test-results.html --self-contained-html \
           --cov=${{ inputs.cov_project }} --no-cov-on-fail \
           --cov-report=html --cov-report=xml --doctest-modules \

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# dropbox
+**/.dropbox


### PR DESCRIPTION
The "uninstall casacore + install casatools" step is a bit hacky but serves as a short-term workaround to get the casatools-backend testing covered.

https://github.com/casangi/xradio/actions/runs/14763424188